### PR TITLE
Allow running r.js in either Node or Java

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ REQUIRE_DEBUG = settings.DEBUG
 
 # A tuple of files to exclude from the compilation result of r.js.
 REQUIRE_EXCLUDE = ("build.txt",)
+
+# The execution environment in which to run r.js: node or rhino.
+REQUIRE_ENVIRONMENT = "rhino"
 ```
 
 

--- a/require/conf.py
+++ b/require/conf.py
@@ -28,8 +28,8 @@ class LazySettings(object):
         return getattr(django_settings, "REQUIRE_EXCLUDE", ("build.txt",))
     
     @property
-    def REQUIRE_NODE(self):
-        return getattr(django_settings, "REQUIRE_NODE", False)
+    def REQUIRE_ENVIRONMENT(self):
+        return getattr(django_settings, "REQUIRE_ENVIRONMENT", "rhino")
     
     
 settings = LazySettings()

--- a/require/storage.py
+++ b/require/storage.py
@@ -31,7 +31,7 @@ class TemporaryCompileEnvironment(object):
     
     def run_optimizer(self, *args, **kwargs):
         # Configure the compiler.
-        if require_settings.REQUIRE_NODE:
+        if require_settings.REQUIRE_ENVIRONMENT == "node":
             compiler_args = self.node_args()
         else:
             compiler_args = self.java_args()


### PR DESCRIPTION
I added a configuration option and some minor code changes to allow using Node instead of Java to run the optimizer.  In my use case making this switch reduces the duration of the run by a factor of 4.  It means using UglifyJS instead of Closure Compiler, but in my case the size difference between the output of the two is negligible.
