### PR TITLE
python 2.6.8 compatibility, remove trailing spaces

### DIFF
--- a/require/tests/__init__.py
+++ b/require/tests/__init__.py
@@ -9,19 +9,19 @@ from require.templatetags.require import require_module
 
 
 class WorkingDirMixin(object):
-    
+
     def __init__(self, *args, **kwargs):
         super(WorkingDirMixin, self).__init__(*args, **kwargs)
         self._working_dirs = []
-    
+
     def _make_working_dir(self):
         working_dir = tempfile.mkdtemp()
         self._working_dirs.append(working_dir)
         return working_dir
-    
+
     def setUp(self):
         self.working_dir = self._make_working_dir()
-        
+
     def tearDown(self):
         for working_dir in self._working_dirs:
             shutil.rmtree(working_dir, ignore_errors=True)
@@ -29,53 +29,53 @@ class WorkingDirMixin(object):
 
 
 class RequireInitTest(WorkingDirMixin, TestCase):
-    
+
     def testCopyRequire(self):
         with self.settings(STATICFILES_DIRS=(self.working_dir,), REQUIRE_JS="require.js"):
             call_command("require_init", verbosity=0)
             self.assertTrue(os.path.exists(os.path.join(self.working_dir, require_settings.REQUIRE_BASE_URL, "require.js")))
-    
+
     def testCopyRequireRelative(self):
         with self.settings(STATICFILES_DIRS=(self.working_dir,), REQUIRE_JS="../require.js"):
             call_command("require_init", verbosity=0)
             self.assertTrue(os.path.exists(os.path.abspath(os.path.join(self.working_dir, require_settings.REQUIRE_BASE_URL, "..", "require.js"))))
-            
+
     def testCopyBuildProfile(self):
         build_profile = "app.build.js"
         with self.settings(STATICFILES_DIRS=(self.working_dir,), REQUIRE_BUILD_PROFILE=build_profile):
             call_command("require_init", verbosity=0)
             self.assertTrue(os.path.exists(os.path.join(self.working_dir, require_settings.REQUIRE_BASE_URL, build_profile)))
-            
+
     def testCopyStandaloneProfile(self):
         standalone_profile = "module.build.js"
         with self.settings(STATICFILES_DIRS=(self.working_dir,), REQUIRE_STANDALONE_MODULES={"main": {"build_profile": standalone_profile}}):
             call_command("require_init", verbosity=0)
             self.assertTrue(os.path.exists(os.path.join(self.working_dir, require_settings.REQUIRE_BASE_URL, standalone_profile)))
-            
+
     def testCopyRequireCustomDir(self):
         with self.settings(REQUIRE_JS="require.js"):
             call_command("require_init", dir=self.working_dir, verbosity=0)
             self.assertTrue(os.path.exists(os.path.join(self.working_dir, require_settings.REQUIRE_BASE_URL, "require.js")))
-        
-        
+
+
 class RequireModuleTest(TestCase):
-    
+
     def testRequireModule(self):
         with self.settings(REQUIRE_JS="require.js", REQUIRE_BASE_URL="js", REQUIRE_STANDALONE_MODULES={}):
-            self.assertHTMLEqual(require_module("main"), """<script src="{}" data-main="{}"></script>""".format(
+            self.assertHTMLEqual(require_module("main"), """<script src="{0}" data-main="{1}"></script>""".format(
                 staticfiles_storage.url("js/require.js"),
                 staticfiles_storage.url("js/main.js"),
             ))
-            
+
     def testStandaloneRequireModule(self):
         with self.settings(REQUIRE_JS="require.js", REQUIRE_BASE_URL="js", REQUIRE_DEBUG=False, REQUIRE_STANDALONE_MODULES={"main": {"out": "main-built.js"}}):
-            self.assertHTMLEqual(require_module("main"), """<script src="{}"></script>""".format(
+            self.assertHTMLEqual(require_module("main"), """<script src="{0}"></script>""".format(
                 staticfiles_storage.url("js/main-built.js"),
             ))
-             
-            
+
+
 class OptimizedStaticFilesStorageTestsMixin(WorkingDirMixin):
-    
+
     def __init__(self, *args, **kwargs):
         super(OptimizedStaticFilesStorageTestsMixin, self).__init__(*args, **kwargs)
         if not self.has_environment():
@@ -84,13 +84,13 @@ class OptimizedStaticFilesStorageTestsMixin(WorkingDirMixin):
             self.testCollectStaticBuildProfile = unittest.skip(skip_message)(self.testCollectStaticBuildProfile)
             self.testCollectStaticStandalone = unittest.skip(skip_message)(self.testCollectStaticStandalone)
             self.testCollectStaticStandaloneBuildProfile = unittest.skip(skip_message)(self.testCollectStaticStandaloneBuildProfile)
-    
+
     def has_environment(self):
         try:
             return subprocess.call(self.require_environment_detection_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE) == 0
         except OSError:
             return False
-    
+
     def setUp(self):
         super(OptimizedStaticFilesStorageTestsMixin, self).setUp()
         self.output_dir = self._make_working_dir()
@@ -109,11 +109,11 @@ class OptimizedStaticFilesStorageTestsMixin(WorkingDirMixin):
             os.path.join(self.test_resources_dir, "util.js"),
             os.path.join(self.working_dir, "js", "util.js"),
         )
-    
+
     def testCollectStatic(self):
         with self.settings(REQUIRE_ENVIRONMENT=self.require_environment, STATICFILES_FINDERS=("require.tests.finders.TestableFileSystemFinder",), STATICFILES_DIRS=(self.working_dir,), STATIC_ROOT=self.output_dir, STATICFILES_STORAGE="require.tests.storage.TestableOptimizedStaticFilesStorage", REQUIRE_JS="require.js", REQUIRE_BASE_URL="js", REQUIRE_STANDALONE_MODULES={}, REQUIRE_BUILD_PROFILE=None):
             call_command("collectstatic", interactive=False, verbosity=0)
-            
+
     def testCollectStaticBuildProfile(self):
         shutil.copyfile(
             os.path.join(self.test_resources_dir, self.test_build_profile),
@@ -121,12 +121,12 @@ class OptimizedStaticFilesStorageTestsMixin(WorkingDirMixin):
         )
         with self.settings(REQUIRE_ENVIRONMENT=self.require_environment, STATICFILES_FINDERS=("require.tests.finders.TestableFileSystemFinder",), STATICFILES_DIRS=(self.working_dir,), STATIC_ROOT=self.output_dir, STATICFILES_STORAGE="require.tests.storage.TestableOptimizedStaticFilesStorage", REQUIRE_JS="require.js", REQUIRE_BASE_URL="js", REQUIRE_STANDALONE_MODULES={}, REQUIRE_BUILD_PROFILE="app.build.js"):
             call_command("collectstatic", interactive=False, verbosity=0)
-            
+
     def testCollectStaticStandalone(self):
         with self.settings(REQUIRE_ENVIRONMENT=self.require_environment, STATICFILES_FINDERS=("require.tests.finders.TestableFileSystemFinder",), STATICFILES_DIRS=(self.working_dir,), STATIC_ROOT=self.output_dir, STATICFILES_STORAGE="require.tests.storage.TestableOptimizedStaticFilesStorage", REQUIRE_JS="require.js", REQUIRE_BUILD_PROFILE=None, REQUIRE_BASE_URL="js", REQUIRE_STANDALONE_MODULES={"main": {"out": "main-built.js"}}):
             call_command("collectstatic", interactive=False, verbosity=0)
             self.assertTrue(os.path.exists(os.path.join(self.output_dir, "js", "main-built.js")))
-            
+
     def testCollectStaticStandaloneBuildProfile(self):
         shutil.copyfile(
             os.path.join(self.test_resources_dir, self.test_standalone_build_profile),
@@ -135,25 +135,25 @@ class OptimizedStaticFilesStorageTestsMixin(WorkingDirMixin):
         with self.settings(REQUIRE_ENVIRONMENT=self.require_environment, STATICFILES_FINDERS=("require.tests.finders.TestableFileSystemFinder",), STATICFILES_DIRS=(self.working_dir,), STATIC_ROOT=self.output_dir, STATICFILES_STORAGE="require.tests.storage.TestableOptimizedStaticFilesStorage", REQUIRE_JS="require.js", REQUIRE_BUILD_PROFILE=None, REQUIRE_BASE_URL="js", REQUIRE_STANDALONE_MODULES={"main": {"out": "main-built.js", "build_profile": "main.build.js"}}):
             call_command("collectstatic", interactive=False, verbosity=0)
             self.assertTrue(os.path.exists(os.path.join(self.output_dir, "js", "main-built.js")))
-            
+
 
 class OptimizedStaticFilesStorageNodeTest(OptimizedStaticFilesStorageTestsMixin, TestCase):
-    
+
     require_environment_detection_args = ("node", "-v")
-    
+
     require_environment = "node"
-    
+
     test_build_profile = "app.build.js"
-    
+
     test_standalone_build_profile = "module.build.js"
-    
+
 
 class OptimizedStaticFilesStorageRhinoTest(OptimizedStaticFilesStorageTestsMixin, TestCase):
-    
+
     require_environment_detection_args = ("java", "-version")
-    
+
     require_environment = "rhino"
-    
+
     test_build_profile = "app.build.closure.js"
-    
+
     test_standalone_build_profile = "module.build.closure.js"


### PR DESCRIPTION
This pull request is for updates to support Python 2.6
My editor also removed trailing spaces, hope you don't mind.

The tests all passed, although I'm not sure if I ran them right (I ran `./manage.py test require.tests` within a django project that uses django-require)
