### PR TITLE
Fixed iterator for python 3

### DIFF
--- a/require/storage.py
+++ b/require/storage.py
@@ -67,7 +67,7 @@ class OptimizedFilesMixin(object):
     REQUIRE_COPY_BLOCK_SIZE = 1024*1024  # 1 MB.
 
     def _file_iter(self, handle):
-        return iter(partial(handle.read, self.REQUIRE_COPY_BLOCK_SIZE), "")
+        return iter(partial(handle.read, self.REQUIRE_COPY_BLOCK_SIZE), b'')
 
     def post_process(self, paths, dry_run=False, verbosity=1, **options):
         # If this is a dry run, give up now!


### PR DESCRIPTION
Small fix for an issue which prevented running `collectstatic` on Python3 - iterator never receives str("") because it is binary in Python 3.
