### PR TITLE
Make default build profile optional

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,6 +39,8 @@ RequireJS.
 
     # The name of a build profile to use for your project, relative to REQUIRE_BASE_URL.
     # A sensible value would be 'app.build.js'. Leave blank to use the built-in default build profile.
+    # Set to False to disable running the default profile (e.g. if only using it to build Standalone
+    # Modules)
     REQUIRE_BUILD_PROFILE = None
 
     # The name of the require.js script used by your project, relative to REQUIRE_BASE_URL.

--- a/require/management/commands/require_init.py
+++ b/require/management/commands/require_init.py
@@ -58,7 +58,7 @@ class Command(NoArgsCommand):
         resources = [
             ("require.js", require_settings.REQUIRE_JS),
         ]
-        if require_settings.REQUIRE_BUILD_PROFILE is not None:
+        if require_settings.REQUIRE_BUILD_PROFILE not in (False, None):
             resources.append(("app.build.js", require_settings.REQUIRE_BUILD_PROFILE))
         for standalone_config in require_settings.REQUIRE_STANDALONE_MODULES.values():
             if "build_profile" in standalone_config:

--- a/require/storage.py
+++ b/require/storage.py
@@ -96,16 +96,17 @@ class OptimizedFilesMixin(object):
                 # Store details of file.
                 compile_info[name] = hash.digest()
             # Run the optimizer.
-            if require_settings.REQUIRE_BUILD_PROFILE is not None:
-                app_build_js_path = env.compile_dir_path(require_settings.REQUIRE_BUILD_PROFILE)
-            else:
-                app_build_js_path = env.resource_path("app.build.js")
-            env.run_optimizer(
-                app_build_js_path,
-                dir = env.build_dir,
-                appDir = env.compile_dir,
-                baseUrl = require_settings.REQUIRE_BASE_URL,
-            )
+            if require_settings.REQUIRE_BUILD_PROFILE is not False:
+                if require_settings.REQUIRE_BUILD_PROFILE is not None:
+                    app_build_js_path = env.compile_dir_path(require_settings.REQUIRE_BUILD_PROFILE)
+                else:
+                    app_build_js_path = env.resource_path("app.build.js")
+                env.run_optimizer(
+                    app_build_js_path,
+                    dir = env.build_dir,
+                    appDir = env.compile_dir,
+                    baseUrl = require_settings.REQUIRE_BASE_URL,
+                )
             # Compile standalone modules.
             if require_settings.REQUIRE_STANDALONE_MODULES:
                 shutil.copyfile(


### PR DESCRIPTION
In my project, I don't want the default build profile to get run as I'm just using require to build the modules with almond.js

This PR allows you to set `REQUIRE_BUILD_PROFILE=False` to disable the default profile

The same as this commit, with docs and a test case: https://github.com/DjangoAdminHackers/django-require/commit/2e2f52014850b4063f14d90fa0c9914897fcf608
