### PR TITLE
Indicate that REQUIRE_BASE_URL is relative.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,9 @@ RequireJS.
 
 ::
 
-    # The baseUrl to pass to the r.js optimizer.
+    # The baseUrl to pass to the r.js optimizer, relative to STATIC_ROOT.
+    # Note that the optimization is done in the temporary directory, actually.
+    # {% require_module %} tag also use this as a base URL, relative to STATIC_URL, to create URL for your main module.
     REQUIRE_BASE_URL = "js"
 
     # The name of a build profile to use for your project, relative to REQUIRE_BASE_URL.


### PR DESCRIPTION
When I was new to this library, I was confused about what to specify as a `REQUIRE_BASE_URL`. I've tried both a filesystem path to my django app's static dir e.g. `/path/to/myproject/myapp/static` and an absolute URL to static assets e.g. `/static/`. But they didn't work fine. After seeing [a topic in the forum](https://groups.google.com/forum/#!topic/django-require/kVUgulN4uf0), I realized that there should be a **relative** path.

As my English is not so good, please feel free to close this pull request and rewrite by yourself.
