### PR TITLE
Added OptimizedManifestStaticFilesStorage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,8 +20,9 @@ Installation
    ``pip install django-require``.
 2. Add ``'require'`` to your ``INSTALLED_APPS`` setting.
 3. Set your ``STATICFILES_STORAGE`` setting to
-   ``'require.storage.OptimizedStaticFilesStorage'`` or
-   ``'require.storage.OptimizedCachedStaticFilesStorage'``.
+   ``'require.storage.OptimizedStaticFilesStorage'``,
+   ``'require.storage.OptimizedCachedStaticFilesStorage'`` or
+   ``'require.storage.OptimizedManifestStaticFilesStorage'``.
 
 Available settings
 ------------------
@@ -159,7 +160,7 @@ The r.js optimizer is run automatically whenever you call the
 ``collectstatic`` management command. The optimizer is run as a
 post-processing step on your static files.
 
-django-require provides two storage classes that are ready to use with
+django-require provides three storage classes that are ready to use with
 the r.js optimizer:
 
 -  ``require.storage.OptimizedStaticFilesStorage`` - A filesystem-based
@@ -167,6 +168,12 @@ the r.js optimizer:
 -  ``require.storage.OptimizedCachedStaticFilesStorage`` - As above, but
    fingerprints all files with an MD5 hash of their contents for HTTP
    cache-busting.
+-  ``require.storage.OptimizedManifestStaticFilesStorage`` - As above, but
+   fingerprints all files with an MD5 hash of their contents for HTTP
+   cache-busting and stores the fingerprints in a JSON file on disk instead
+   of using a cache. Please note that the
+   ``OptimizedManifestStaticFilesStorage`` is only available in Django 1.7 and
+   above.
 
 Creating your own optimizing storage classes
 --------------------------------------------

--- a/require/storage.py
+++ b/require/storage.py
@@ -181,3 +181,13 @@ class OptimizedStaticFilesStorage(OptimizedFilesMixin, StaticFilesStorage):
 class OptimizedCachedStaticFilesStorage(OptimizedFilesMixin, CachedStaticFilesStorage):
 
     pass
+
+
+try:
+    from django.contrib.staticfiles.storage import ManifestStaticFilesStorage
+except ImportError:  # Django < 1.7
+    pass
+else:
+    class OptimizedManifestStaticFilesStorage(OptimizedFilesMixin, ManifestStaticFilesStorage):
+
+        pass


### PR DESCRIPTION
In 1.7, Django added the [ManifestStaticFilesStorage](https://docs.djangoproject.com/en/1.7/ref/contrib/staticfiles/#manifeststaticfilesstorage) which is basically the same as the CachedFilesStorage, but uses a JSON file on disk instead of a cache backend.

I added code to add that for 1.7+, it should do nothing in <1.7.