### PR TITLE
Allow insertRequire for standalone modules without requiring multiple build files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ build
 MANIFEST
 htmlcov
 *.egg-info
+.idea

--- a/README.rst
+++ b/README.rst
@@ -150,6 +150,14 @@ To specify standalone modules, simply add them to your
 
             # Optional: A build profile used to build this standalone module.
             "build_profile": "main.build.js",
+
+            # Optional: A require(['main-built.js']); call for the standalone module will be included
+            # at the end of the built standalone, resulting in the immediate initialization
+            # of the module when the page loads. This is a convenience for the insertRequire
+            # behavior of the standard optimizer build config that will automatically require
+            # the module configured without requiring you to specify a separate build file for
+            # each
+            "insert_require": True,
         }
     }
 

--- a/require/storage.py
+++ b/require/storage.py
@@ -120,13 +120,30 @@ class OptimizedFilesMixin(object):
                         module_build_js_path = env.compile_dir_path(standalone_config["build_profile"])
                     else:
                         module_build_js_path = env.resource_path("module.build.js")
-                    env.run_optimizer(
-                        module_build_js_path,
-                        name = "almond",
-                        include = standalone_module,
-                        out = env.build_dir_path(standalone_config["out"]),
-                        baseUrl = os.path.join(env.compile_dir, require_settings.REQUIRE_BASE_URL),
-                    )
+
+                    if "insert_require" in standalone_config:
+
+                        require_script = standalone_module if standalone_config['insert_require'] == True else standalone_config['insert_require']
+
+                        env.run_optimizer(
+                            module_build_js_path,
+                            name = "almond",
+                            include = standalone_module,
+                            out = env.build_dir_path(standalone_config["out"]),
+                            baseUrl = os.path.join(env.compile_dir, require_settings.REQUIRE_BASE_URL),
+                            insertRequire = require_script
+                        )
+
+                    else:
+
+                        env.run_optimizer(
+                            module_build_js_path,
+                            name = "almond",
+                            include = standalone_module,
+                            out = env.build_dir_path(standalone_config["out"]),
+                            baseUrl = os.path.join(env.compile_dir, require_settings.REQUIRE_BASE_URL)
+                        )
+
                 else:
                     raise ImproperlyConfigured("No 'out' option specified for module '{module}' in REQUIRE_STANDALONE_MODULES setting.".format(
                         module = standalone_module


### PR DESCRIPTION
@etianen , I found myself desiring this functionality for my own project since I found I really want to use the same build profile for lots of main modules (I have one main per page across a multi-page site). 

If this seems too one off I totally understand. Another thought that crossed my mind was maybe specifying a few reserved string keywords that can be used in the STANDALONE config that get auto-replaced based on the module being configured, etc.

I could have also cleaned things up into a single kwargs instead of a branch but wasn't sure what you prefer. Let me know what you think!