### PR TITLE
Use `mark_safe` for the output of the `require_module` templatetag

### DIFF
--- a/require/templatetags/require.py
+++ b/require/templatetags/require.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 from django import template
 
 from django.contrib.staticfiles.storage import staticfiles_storage
+from django.utils.safestring import mark_safe
 
 from require.conf import settings as require_settings
 from require.helpers import resolve_require_url, resolve_require_module
@@ -15,16 +16,22 @@ register = template.Library()
 def require_module(module):
     """
     Inserts a script tag to load the named module, which is relative to the REQUIRE_BASE_URL setting.
-    
+
     If the module is configured in REQUIRE_STANDALONE_MODULES, and REQUIRE_DEBUG is False, then
     then the standalone built version of the module will be loaded instead, bypassing require.js
     for extra load performance.
     """
     if not require_settings.REQUIRE_DEBUG and module in require_settings.REQUIRE_STANDALONE_MODULES:
-        return """<script src="{module}"></script>""".format(
-            module = staticfiles_storage.url(resolve_require_module(require_settings.REQUIRE_STANDALONE_MODULES[module]["out"])),
+        return mark_safe(
+            """<script src="{module}"></script>""".format(
+                module=staticfiles_storage.url(
+                    resolve_require_module(require_settings.REQUIRE_STANDALONE_MODULES[module]["out"])),
+            )
         )
-    return """<script src="{src}" data-main="{module}"></script>""".format(
-        src = staticfiles_storage.url(resolve_require_url(require_settings.REQUIRE_JS)),
-        module = staticfiles_storage.url(resolve_require_module(module)),
+
+    return mark_safe(
+        """<script src="{src}" data-main="{module}"></script>""".format(
+            src=staticfiles_storage.url(resolve_require_url(require_settings.REQUIRE_JS)),
+            module=staticfiles_storage.url(resolve_require_module(module)),
+        )
     )


### PR DESCRIPTION
Django 1.9 has changed how `register.simple_tag` handles escaping:

https://docs.djangoproject.com/en/1.9/howto/custom-template-tags/#django.template.Library.simple_tag

Their recommendation is to use either `format_html` or `mark_safe`.
Since this looks like a very short small fragment, the latter seems
like the right solution.

I also checked that `mark_safe` has been around since Django 1.4, so
this should not break backwards compatibility, as Django 1.7 is the
minimum requirement.