### PR TITLE
django 1.10 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,10 @@ script: tox
 notifications:
   email: false
 env:
-  - TOXENV=py27-django-17
   - TOXENV=py27-django-18
   - TOXENV=py27-django-19
-  - TOXENV=py33-django-17
+  - TOXENV=py27-django-110
   - TOXENV=py33-django-18
-  - TOXENV=py34-django-17
   - TOXENV=py34-django-18
   - TOXENV=py34-django-19
+  - TOXENV=py34-django-110

--- a/require/conf.py
+++ b/require/conf.py
@@ -4,35 +4,35 @@ from django.conf import settings as django_settings
 
 
 class LazySettings(object):
-    
+
     @property
     def REQUIRE_BASE_URL(self):
         return getattr(django_settings, "REQUIRE_BASE_URL", "js")
-    
+
     @property
     def REQUIRE_BUILD_PROFILE(self):
         return getattr(django_settings, "REQUIRE_BUILD_PROFILE", None)
-    
+
     @property
     def REQUIRE_JS(self):
         return getattr(django_settings, "REQUIRE_JS", "require.js")
-    
+
     @property
     def REQUIRE_STANDALONE_MODULES(self):
         return getattr(django_settings, "REQUIRE_STANDALONE_MODULES", {})
-    
+
     @property
     def REQUIRE_DEBUG(self):
         return getattr(django_settings, "REQUIRE_DEBUG", django_settings.DEBUG)
-    
+
     @property
     def REQUIRE_EXCLUDE(self):
         return getattr(django_settings, "REQUIRE_EXCLUDE", ("build.txt",))
-    
+
     @property
     def REQUIRE_ENVIRONMENT(self):
         return getattr(django_settings, "REQUIRE_ENVIRONMENT", "auto")
-    
+
     @property
     def REQUIRE_ENVIRONMENT_ALIASES(self):
         return getattr(django_settings, "REQUIRE_ENVIRONMENT_ALIASES", {
@@ -40,5 +40,5 @@ class LazySettings(object):
             'node': 'require.environments.NodeEnvironment',
             'rhino': 'require.environments.RhinoEnvironment',
             })
-    
+
 settings = LazySettings()

--- a/require/management/commands/require_init.py
+++ b/require/management/commands/require_init.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 
 import os.path, shutil
-from optparse import make_option
 
 from django.core.management.base import BaseCommand, CommandError
 from django.conf import settings
@@ -17,33 +16,32 @@ def default_staticfiles_dir():
 
 
 class Command(BaseCommand):
-    
+
     help = (
         "Copies the base require.js file into your STATICFILES_DIRS.\n\n"
         "Also copies default implementations of any build profiles listed in the REQUIRE_BUILD_PROFILE "
         "and REQUIRE_STANDALONE_MODULES settings."
     )
-    
-    option_list = BaseCommand.option_list + (
-        make_option(
+
+    requires_model_validation = False
+
+    def add_arguments(self, parser):
+        parser.add_argument(
             "-f",
             "--force",
             action = "store_true",
             dest = "force",
             default = False,
-            help = "Overwrite existing files if found.", 
-        ),
-        make_option(
+            help = "Overwrite existing files if found."
+        )
+        parser.add_argument(
             "-d",
             "--dir",
             action = "store",
             dest = "dir",
-            help = "Copy files into the named directory. Defaults to the first item in your STATICFILES_DIRS setting.", 
-        ),
-    )
-    
-    requires_model_validation = False
-    
+            help = "Copy files into the named directory. Defaults to the first item in your STATICFILES_DIRS setting."
+        )
+
     def handle(self, **options):
         verbosity = int(options.get("verbosity", 1))
         # Calculate the destination dir.

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,8 @@
 [tox]
 envlist =
-    {py27,py33,py34}-django-{17,18}
-    {py27,py34}-django-19
+    {py27,py33,py34}-django-18
+    {py27,py34}-django-{19,110}
+skip_missing_interpreters = True
 
 [testenv]
 changedir = {envtmpdir}
@@ -9,11 +10,11 @@ basepython =
     py27: python2.7
     py33: python3.3
     py34: python3.4
-commands = 
+commands =
     coverage run --rcfile={toxinidir}/.coveragerc {toxinidir}/test_project/manage.py test --settings=test_project.settings require -v 2
 deps =
-    django-17: Django>=1.7,<1.8
     django-18: Django>=1.8,<1.9
     django-19: Django>=1.9,<1.10
+    django-110: Django==1.10a1
     tox>=2.0.0
     coverage


### PR DESCRIPTION
Support for Django 1.10 and dropping support for 1.7 (1.8 is LTS release).